### PR TITLE
[DFA-1] Create a Website

### DIFF
--- a/docs/DFA_1_LinktreeSite.md
+++ b/docs/DFA_1_LinktreeSite.md
@@ -1,0 +1,83 @@
+# Abstract
+
+The Digital Freedom Alliance should start organize a digital footprint starting with a simple "linktr.ee"
+style website that links to the DFA policy thesis, action steps, and community conversation. In it's
+simplest form, it should be a one-stop-shop for all information, and should be linked to appropriate
+domains and social media accounts.
+
+# Motivation
+
+This simple linked website can list various assets the organization holds to direct members and interested
+individuals. Many digital organizations have various applications spread across multiple domains. Already,
+discussion in the DFA discord prompted various communication tools and links to material that should be
+considered "standard reading" for interested participants. Along with this, various social media and
+publications will likely be spread across multiple domains, which may include podcasts, youtube accounts,
+and other media.
+
+A simple to use, mobile friendly website should be the go-to solution for the DFA. To begin, offical
+leadership should curate this list as best as possible, but allow organic growth for members to experiment
+with various solutions until a "best-solution" is found.
+
+# Key Metrics
+
+### Daily Hits
+
+- Measure daily hits for the website to measure growth of it's usage.
+
+### Click Through Rates
+
+- Measure click-through rates for various links highlighted on the website.
+
+### Donations
+
+- Measure donation flow through the website. It is assumed donations will be directly linked to the website.
+
+# Specification
+
+Possible options and their considerations for the initial website include:
+
+### Linktr.ee
+
+- Simple to set up, and low cost.
+- Integrates a payment solution for future donations.
+- Easy to manipulate and adjust links, but nothing else.
+- Gives an organized direct-to-action user experience.
+- Doesn't include a way for open-source collaboration on the site itself.
+
+### Github Pages
+
+- Simple to use markdown style pages. Low cost.
+- Doesn't have a payment solution integrated for donations.
+- Open source, so new updates can be decentralized to other members.
+
+### JS.wiki
+
+- Customizable wiki deployable on cloud servers.
+- Uses Digital Ocean for cloud provisioning.
+- Good for organizing long form discussion.
+
+# Considerations
+
+### Twitter
+
+A viable option could be to include twitter as the one-stop shop for news and information relating to the DFA. Some possible issues
+include:
+
+- Requires some curation and a manager of the account, discouraging open-source collaboration of the content.
+
+### Fully Featured Website
+
+Focusing on a fully featured website is a possible option. Directing some energy to a professional long form
+site that users can explore and view news and related readings could be a viable option. Some issues with this are:
+
+- Longer time to market.
+- Requires engineering expertise and discourages open-source updating.
+
+
+# References
+
+See the sites below to compare possible options.
+
+- [Coin Center](https://www.coincenter.org/)
+
+- [Bankless](https://linktr.ee/Bankless)


### PR DESCRIPTION
# Description

The website for the DFA should likely start by linking various documents and social media accounts. This proposal is a "start-from-zero" approach, describing various options to link these accounts.

It is not a full form solution, which might take some time to fully implement. Considerations can be seen in the appropriate sections.